### PR TITLE
Dependency 및 DB Cache를 GCS에 저장하도록 변경

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,18 +50,14 @@ runs:
 
     - name: Cache .venv
       if: inputs.cache-venv == 'true'
-      uses: actions/cache@v3
       id: cache-venv
-      env:
-        cache-name: cache-venv
+      uses: mansagroup/gcs-cache-action@v1.0.3
       with:
+        bucket: zuzu_ci_cache
         path: ./.venv
-        key: v1-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('./Pipfile.lock') }}-${{ github.event.number }}
+        key: venv-${{ runner.os }}-${{ hashFiles('./Pipfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./Pipfile.lock') }}-
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+          venv-${{ runner.os }}-
 
     - name: Check .venv
       id: check-venv

--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,13 @@
 name: "Setup"
+
 inputs:
   cache-venv:
-    default: false
+    default: "false"
   cache-yarn:
-    default: false
+    default: "false"
   cache-db:
-    default: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,11 @@ runs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: "Authenticate to Google Cloud"
+      uses: "google-github-actions/auth@v1"
+      with:
+        credentials_json: ${{ env.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
+
     - name: touch-gcloud-credential-file
       if: inputs.cache-venv == 'true'
       shell: bash
@@ -31,6 +36,17 @@ runs:
       run: |
         pip install pipenv
         python --version ; pip --version ; pipenv --version
+
+    - name: Cache the node_modules
+      if: inputs.cache-yarn == 'true'
+      id: cache-yarn
+      uses: mansagroup/gcs-cache-action@v1.0.3
+      with:
+        bucket: zuzu_ci_cache
+        path: ./node_modules
+        key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          node-modules-${{ runner.os }}-
 
     - name: Cache .venv
       if: inputs.cache-venv == 'true'
@@ -70,12 +86,13 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: "14"
-        cache: "yarn"
 
     - name: Run Yarn Install
-      if: inputs.cache-yarn == 'true'
+      if: inputs.cache-yarn == 'true' && steps.cache-yarn.outputs.cache-hit != 'true'
       shell: bash
-      run: yarn install
+      run: |
+        ./zz deps_react
+        ./zz deps_react_init
 
     - name: Initialize Lerna
       if: steps.cache-yarn.outputs.cache-hit == 'true'

--- a/action.yml
+++ b/action.yml
@@ -97,15 +97,16 @@ runs:
         yarn lerna bootstrap
         yarn lerna exec --parallel yarn link
 
-    - name: Cache DB migration datas 
+    - name: Cache DB migration datas
       if: inputs.cache-db == 'true'
-      uses: actions/cache@v3
       id: cache-db
-      env:
-        cache-name: cache-db
+      uses: mansagroup/gcs-cache-action@v1.0.3
       with:
+        bucket: zuzu_ci_cache
         path: ./db-volume.tar
-        key: v1-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('zuzu/db/migrations/0*') }}
+        key: db-${{ runner.os }}-${{ hashFiles('zuzu/db/migrations/0*') }}
+        restore-keys: |
+          db-${{ runner.os }}-
 
     - name: Extract the compressed DB migration datas
       if: inputs.cache-db == 'true' && steps.cache-db.outputs.cache-hit == 'true'
@@ -127,4 +128,3 @@ runs:
         # actions/cache에서는 'docker' usergroup이 소유하고 있는 파일에 접근할 수 없어, 부득이하게 Docker volume의 압축파일을 생성하여 캐시한다.
         # See https://github.com/actions/cache/issues/31
         sudo tar -cvf db-volume.tar ./db-volume
-


### PR DESCRIPTION
`mansagroup/gcs-cache-action@v1.0.3`가 도입됨.
사용자가 많지 않아 신뢰도가 크게 높지는 않으며, Public Archive이긴 하나 언제든 개발자가 Archive를 풀고 코드를 변경할 수 있기 때문에, 장기적인 안정성 측면에서도 문제가 있음. 