### PR TITLE
DB 볼륨 캐시 tar 의 간헐적 CI 실패(tar race) 수정

### DIFF
--- a/cache-db/action.yml
+++ b/cache-db/action.yml
@@ -42,4 +42,10 @@ runs:
 
         # actions/cache에서는 'docker' usergroup이 소유하고 있는 파일에 접근할 수 없어, 부득이하게 Docker volume의 압축파일을 생성하여 캐시한다.
         # See https://github.com/actions/cache/issues/31
+        #
+        # 살아있는 postgres 의 데이터 디렉토리를 tar 하면 WAL 쓰기와 읽기가 겹쳐
+        # "file changed as we read it" 으로 tar 가 exit 1 을 내고, 이 스텝이 간헐적으로 실패한다.
+        # db 를 멈춰 데이터 디렉토리를 정지시킨 뒤 tar 해야 레이스가 없고, clean shutdown 상태라
+        # 복원 시에도 일관된(WAL replay 불필요) 스냅샷이 된다.
+        docker compose -f ./docker/testing.yaml stop db
         sudo tar -cvf db-volume.tar ./db-volume


### PR DESCRIPTION
## 문제

`captain` CI 의 django-test 잡이 **종종** 다음 트레이스백으로 실패했습니다:

```
FileNotFoundError: [Errno 2] No such file or directory: 'timings.log'
```

이건 표면 증상이고, 실제 원인은 이 액션의 `cache-db` → **"Compress the DB migration datas"** 스텝입니다. 살아있는 postgres 컨테이너의 데이터 디렉토리를 그대로 tar 하다 보니, postgres 가 WAL 파일(`pg_wal/...`)을 쓰는 도중 tar 가 그 파일을 읽으면:

```
tar: ./db-volume/pg_wal/0000000100000000000000XX: file changed as we read it
##[error]Process completed with exit code 1.
```

`shell: bash` 의 `-e` 때문에 tar 의 exit 1 이 스텝 전체를 실패시킵니다. 그러면 setup-action 이 실패 → captain 워크플로의 테스트 스텝(`... | tee timings.log`)이 skip → `timings.log` 미생성 → `if: always()` 로 도는 타이밍 렌더 스텝이 `FileNotFoundError` 로 죽는 연쇄였습니다.

**재실행하면 통과**하는 이유도 이걸로 설명됩니다 — tar 읽기와 WAL 쓰기가 겹치느냐는 매 실행 타이밍에 달린 race 라, 대부분 재실행 시 안 겹쳐 성공합니다.

## 변경

tar 직전에 `docker compose ... stop db` 로 db 컨테이너를 멈춰 데이터 디렉토리를 정지 상태로 만듭니다. 레이스가 원천 제거되고, clean shutdown 상태라 복원 시 WAL replay 가 불필요한 **일관된 스냅샷**이 됩니다.

이후 동작에도 안전합니다 — 이 스텝 뒤엔 setup 이 끝나고, 워크플로의 테스트 스텝이 `docker compose ... up -d` 로 db 를 새로 띄웁니다.

## 테스트 필요 범위

- cache miss 경로(스냅샷 새로 생성)에서 tar 가 exit 1 없이 통과하는지.
- 생성된 `db-volume.tar` 가 cache hit 경로(`tar -xvf`)로 복원되어 테스트가 정상 동작하는지.

## 참고

연쇄의 끝단(타이밍 렌더 스텝)이 무관한 트레이스백을 덧씌우던 문제는 captain 레포에서 별도 방어 PR 로 처리했습니다(파일 없으면 안내 후 정상 종료).

🤖 Generated with [Claude Code](https://claude.com/claude-code)